### PR TITLE
Fixed compiling under 2.8

### DIFF
--- a/sources/MyRuLib/controls/FbSearchCtrl.cpp
+++ b/sources/MyRuLib/controls/FbSearchCtrl.cpp
@@ -10,9 +10,6 @@
 
 #include "FbSearchCtrl.h"
 
-#ifdef FB_SEARCH_COMBO_CTRL
-
-#include <wx/image.h>
 
 #define WXMAX(a,b) ((a)>(b)?(a):(b))
 
@@ -102,6 +99,10 @@ static int GetMultiplier()
     return 6;
 #endif
 }
+
+#ifdef FB_SEARCH_COMBO_CTRL
+
+#include <wx/image.h>
 
 IMPLEMENT_CLASS(FbSearchCtrl, wxOwnerDrawnComboBox)
 


### PR DESCRIPTION
При добавлении сборки с wxGTK >= 2.9 в код вкралась ошибка, которая заметна только при сборке с wx 2.8. В приложенном патче исправление.